### PR TITLE
Update homepage research/publications and refresh CV sections

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -13,20 +13,21 @@ My advisors are Prof. [Yannick Sire](https://scholar.google.com/citations?hl=en&
 Research Topics
 ------
 * Statistical Machine Learning
-* Paritial Differential Equations
+* LLM Agents
+* Partial Differential Equations
+* AI for Science
 
 
 Publication (α-β for alphabetical order)
 ------
-* Thomas Y. Hou, Xiang Qin, Yannick Sire, **Yantao Wu** (α-β). (2026) Self-similar blow-up profile for the one-dimensional reduction of generalized SQG with infinite energy. [arXiv](https://arxiv.org/abs/2603.11301).
+* **Yantao Wu**, Mauro Maggioni. *Conditional Regression for the Nonlinear Single-Variable Model*. *Journal of Machine Learning Research*, revise & resubmit. [arXiv:2411.09686](https://arxiv.org/abs/2411.09686).
 
-* Fanghua Lin, Yannick Sire, **Yantao Wu** (α-β), Yifu Zhou. (2026) Liquid crystals and topological vorticity: smoothness of mild solutions. [arXiv](https://arxiv.org/abs/2601.18726).
+* Thomas Y. Hou, Xiang Qin, Yannick Sire, **Yantao Wu** (α-β). *Self-similar blow-up profile for the one-dimensional reduction of generalized SQG with infinite energy*. (2026). [arXiv:2603.11301](https://arxiv.org/abs/2603.11301).
 
-* **Yantao Wu**, Mauro Maggioni. (2024). Conditional regression for the Nonlinear Single-Variable Model. [arXiv](https://arxiv.org/abs/2411.09686). Jorunal of Machine Learning Research, under review (revise & resubmit). 
+* Fanghua Lin, Yannick Sire, **Yantao Wu** (α-β), Yifu Zhou. *Liquid crystals and topological vorticity: smoothness of mild solutions*. (2026). [arXiv:2601.18726](https://arxiv.org/abs/2601.18726).
 
-* Yannick Sire, **Yantao Wu** (α-β), and Yifu Zhou. (2024). Global existence of weak solutions to the two‐dimensional nematic liquid crystal flow with partially free boundary. Journal of the London Mathematical Society. 110. 10.1112/jlms.70008.  [[paper](https://londmathsoc.onlinelibrary.wiley.com/doi/10.1112/jlms.70008) [arXiv](https://arxiv.org/abs/2308.04358)]
+* Yannick Sire, **Yantao Wu** (α-β), Yifu Zhou. *Global Existence of Weak Solutions to the Two Dimensional Nematic Liquid Crystal Flow with Partially Free Boundary*. *Journal of the London Mathematical Society*, 110, 2025. [[paper](https://londmathsoc.onlinelibrary.wiley.com/doi/10.1112/jlms.70008) · [arXiv:2308.04358](https://arxiv.org/abs/2308.04358)]
 
-* Yannick Sire, **Yantao Wu** (α-β), Yifu Zhou.  Geometric variational problems with free boundary: harmonic maps, minimal surfaces and applications to a new model of Liquid Crystal Flow. Coimbra Mathematical Texts, to appear.
+* Yannick Sire, **Yantao Wu** (α-β), Yifu Zhou. *Geometric variational problems with free boundary: harmonic maps, minimal surfaces and applications to a new model of Liquid Crystal Flow*. *Coimbra Mathematical Texts, Modern methods in the analysis of free boundary problems*, to appear.
 
-* Lee Kennard, **Yantao Wu** (α-β). Halperin’s Conjecture in Formal Dimensions up to 20. Communication in Algebra. 2023, Volume 51, Issue 8. [[paper](https://www.tandfonline.com/doi/abs/10.1080/00927872.2023.2186705) [arXiv](https://arxiv.org/abs/2104.04086)]
-
+* Lee Kennard, **Yantao Wu** (α-β). *Halperin's Conjecture in Formal Dimensions up to 20*. *Communications in Algebra*, Volume 51, Issue 8, 2023. [[paper](https://www.tandfonline.com/doi/abs/10.1080/00927872.2023.2186705) · [arXiv:2104.04086](https://arxiv.org/abs/2104.04086)]

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -12,60 +12,46 @@ redirect_from:
 Education
 ------
 
-* Ph.D. program in Mathematics, 2021 - Now
-  * Research Topics: Nonparametric Statistical Learning, Theoretical Machine Learning, Supervised Learning Theory, Parabolic Partial Differential Equations.
-  * Coursework: Riemannian Geometry, Algebraic Topology, Harmonic Analysis, Partial Differential Equations, Stochastic Differential Equation, High-Dimensional Probability, Probabilistic Machine Learning
-and Diffusion Generative Models, Stochastic Controls and Reinforcement Learning, coding Large Language Models.
-* B.S. in Mathematics & B.A. in Physics, Syracuse University, 2018 - 2021
+* **Johns Hopkins University, Baltimore, MD** (Sep 2021 – Present)
+  * Ph.D. Candidate in Mathematics
+  * Advisors: Prof. Mauro Maggioni and Prof. Yannick Sire
+* **Syracuse University, Syracuse, NY** (Jan 2018 – May 2021)
+  * Dual Degree: B.S. in Mathematics and B.A. in Physics
   * *Summa Cum Laude* (Cumulative GPA: 3.992/4.000)
   * Distinction in Mathematics
   * Syracuse University Scholar
   * Member of Phi Beta Kappa
-  * Math Department Awards: Euclid Prize in 2020 & Archimedes Prize in 2021 
-  * Physics Department Award: Neil F. Beardsley Prize in 2021
 
 Academic Awards
 ------
 
-* Chinese Mathematical Olympiad: First prize in provincial level in 2017
-* Chinese Physics Olympiad: First prize in provincial level in 2017
-* William Lowell Putnam Mathematical Competition: ranked in top 15% nationwide in 2018&2019
+* Chinese Mathematical Olympiad: Provincial First Prize, 2017
+* Chinese Physics Olympiad: Provincial First Prize, 2017
+* William Lowell Putnam Mathematical Competition: ranked in the top 15% nationally in 2018 and 2019
+* Mathematics Department Awards: Euclid Prize, 2020; Archimedes Prize, 2021
+* Physics Department Award: Neil F. Beardsley Prize, 2021
 
-Research Topics:
+Research Topics
 ------
 
-* Nonparametric Statistical Learning
-We consider nonlinear functional compositional structures that generalize the linear single-index or multi-
-index model, and develop new algorithms to achieve the goal of obtaining the minimax nonparametric
-rate corresponding without suffering from the curse of dimensionality. These novel algorithms cover a
-wide range of tools from statistical learning, including conditional regression, local kernel regression, gra-
-dient estimates, nonlinear feature learning, and high dimensional classification. The proposed minimax
-nonparametric rate is both proved in theoretically and verified in numerical simulations.
-* Theoretical Machine Learning
-Study theoretical analysis of neural networks, including random feature model, Weisserstein Gradient
-Flow, neural tangent kernels, and maximal update parameterization in hyper-parameter transfer. In
-particular, our research cover the topics of error landscape in the problem of learning single-index and
-multi-index model via neural networks. Moreover, our research cover topics of use interacting particle
-systems and its mean-field limit McKean-Vlasov Equation to study mathematical foundation of MLP
-and transformer.
-* Regularity vs Singularity in Parabolic PDEs
-We consider the problem of regularity of solutions to different types of geometric variational problems of
-partially constrained free boundary, motivated by classical results on regularity vs singularity formation in heat flows of harmonic map. We also study active scalar equations where the fractional Laplacian gives
-many open problems, for example, Regularity vs Singularity in Surface Quasi-Geostrophic equation.
-
-
-Teaching Experience
-------
-
-* Syracuse University: 
-  * Math help room: tutor students on elementary Calculus. 
-  * Teaching Assistant: MAT 412: Introduction to Real Analysis I, MAT 517: Partial Differential Equations and Fourier Series, and MAT 534: Introduction to Abstract Algebra.
-* Johns Hopkins University:
-  * Math help room: tutor students on undergraduate math courses.
-  * Teaching Assistant: Math 107: Calculus II, Math 201: Linear Algebra , Math 202: Calculus III, Math 311: Methods in Complex Analysis.
+* Statistical Machine Learning
+* LLM Agents
+* Partial Differential Equations
+* AI for Science
 
 Technical Skills
 ------
 
-* Programming Languages: Matlab, Python, Mathematica 
-* Software & Tools Microsoft Office, LATEX
+* **ML / AI:** LLM agents, formal verification (Lean, Dafny), model compression, neural operators, generative modeling, flow matching, scientific ML, manifold learning
+* **Programming:** Python, PyTorch, CUDA/MEX, MATLAB
+* **Math & Modeling:** Nonparametric regression, statistical learning theory, PDEs, manifold geometry
+
+Teaching Experience
+------
+
+* **Syracuse University**
+  * Math help room: tutored students on elementary calculus
+  * Teaching Assistant: MAT 412 (Introduction to Real Analysis I), MAT 517 (Partial Differential Equations and Fourier Series), MAT 534 (Introduction to Abstract Algebra)
+* **Johns Hopkins University**
+  * Math help room: tutored students on undergraduate math courses
+  * Teaching Assistant: Math 107 (Calculus II), Math 201 (Linear Algebra), Math 202 (Calculus III), Math 311 (Methods in Complex Analysis)


### PR DESCRIPTION
### Motivation
- Align the website content with the latest English resume found in `files/YantaoWu_CV_claude_ind.tex` by updating research topics and publication formatting. 
- Consolidate and modernize the `/cv/` page to reflect updated Education, Academic Awards, Research Topics, and Technical Skills from the resume while keeping Teaching Experience at the end.

### Description
- Updated `Research Topics` on the homepage (`_pages/about.md`) to include `LLM Agents` and `AI for Science` and fixed the spelling of `Partial Differential Equations`.
- Rewrote the homepage `Publication (α-β for alphabetical order)` block in `_pages/about.md` to match the resume entries and use markdown-friendly bold/italic conventions for authors and titles.
- Replaced the `/cv/` page content (`_pages/cv.md`) for `Education`, `Academic Awards`, `Research Topics`, and `Technical Skills` with resume-aligned entries and moved `Teaching Experience` to the end of the page.
- Source of truth for the edits was the English resume `files/YantaoWu_CV_claude_ind.tex` and changes touch only `_pages/about.md` and `_pages/cv.md`.

### Testing
- Verified repository file list and presence of the resume with a files listing, which succeeded. 
- Inspected the updated file contents using content-display commands (`sed -n` and `nl -ba`) to confirm the new blocks are present and formatted, which succeeded. 
- Compared before/after differences for `_pages/about.md` and `_pages/cv.md` to ensure intended edits were applied, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f158fdefd0832aa300830f20337342)